### PR TITLE
Upgrade BUNDLE WITH version of Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,4 +392,4 @@ DEPENDENCIES
   web-console (>= 4.2.0)
 
 BUNDLED WITH
-   2.3.27
+   2.5.22


### PR DESCRIPTION
Because it is different from the version installed in the container