### PR TITLE
Introduce rubocop-rspec_rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ plugins:
   - rubocop-rails
   - rubocop-factory_bot
   - rubocop-rspec
+  - rubocop-rspec_rails
 
 AllCops:
   NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ group :development do
   gem 'rubocop-rails', require: false
   gem 'rubocop-factory_bot', require: false
   gem 'rubocop-rspec', require: false
+  gem 'rubocop-rspec_rails', require: false
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,6 +313,10 @@ GEM
     rubocop-rspec (3.6.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
+    rubocop-rspec_rails (2.31.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
+      rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -392,6 +396,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  rubocop-rspec_rails
   sass-rails (>= 6.0.0)
   turbolinks
   tzinfo-data

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Users', type: :request do
+describe 'Users' do
   describe "GET index" do
     subject { get '/users' }
 
@@ -62,7 +62,7 @@ describe 'Users', type: :request do
           }
         }
 
-        expect(response.status).to eq 404
+        expect(response).to have_http_status :not_found
       end
     end
   end


### PR DESCRIPTION
Because rspec-rails files should also be linted